### PR TITLE
Fix projects collection output config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ collections:
   involvement_opportunities:
     permalink: /:url
   projects:
-    ouput: true
+    output: true
 
 # Plugins
 plugins:


### PR DESCRIPTION
## Summary
- Fix the `projects` collection option in `_config.yml` from `ouput` to `output`
- Allows Jekyll to emit the existing `_projects` collection entries

## Tests
- `python` static check for `projects.output: true` and absence of `ouput`
- `git diff --check`

## Notes
- Full Jekyll build was not run because Ruby is not installed in this workspace.

Closes #26